### PR TITLE
Update link-checker.yml

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Report broken links
-        uses: urlstechie/urlchecker-action@0.2.2
+        uses: urlstechie/urlchecker-action@0.0.27
         with:
           # A comma-separated list of file types to cover in the URL checks
           # file_types:


### PR DESCRIPTION
We are going to be deprecating older versions of urlchecker (and there was a change in versioning to match the upstream package so the version only appears earlier) so I wanted to update here to make sure your workflows do not break!

The updated versions also run about 7x as fast, so that's an added bonus!